### PR TITLE
handle differences in attrs for list_insts_flat, by using a whitelist

### DIFF
--- a/krs/institutions.py
+++ b/krs/institutions.py
@@ -77,7 +77,7 @@ async def list_insts_flat(experiment=None, filter_func=None, remove_empty=True, 
     """
     raw = await list_insts(experiment, filter_func=filter_func, rest_client=rest_client)
     ret = {}
-    for path in raw:
+    for path in sorted(raw):
         inst_key = path.split('/')[-1]
         attrs = raw[path]
         if remove_empty and not attrs:

--- a/krs/institutions.py
+++ b/krs/institutions.py
@@ -62,13 +62,14 @@ async def list_insts(experiment=None, filter_func=None, rest_client=None):
 class InstitutionAttrsMismatchError(RuntimeError):
     pass
 
-async def list_insts_flat(experiment=None, filter_func=None, rest_client=None):
+async def list_insts_flat(experiment=None, filter_func=None, attr_whitelist=None, rest_client=None):
     """
     List institution names in Keycloak, removing overlaps from multiple experiments.
 
     Args:
         experiment (str): experiment name (default: list all experiments)
         filter_func (callable): given a group path and set of attrs, a callable to return true/false
+        attr_whitelist (iterable): whitelist of attributes (default: all)
 
     Returns:
         dict: name: attrs
@@ -78,8 +79,16 @@ async def list_insts_flat(experiment=None, filter_func=None, rest_client=None):
     for path in raw:
         inst_key = path.split('/')[-1]
         attrs = raw[path]
+        if not attrs:
+            logger.info(f'ignoring inst {path} with no attrs')
+            continue
+        if attr_whitelist:
+            attrs = {k: attrs[k] for k in attrs if k in attr_whitelist}
         if inst_key in ret and ret[inst_key] != attrs:
             logger.warning(f'inst attr mismatch - {inst_key}')
+            for path in raw:
+                if path.split('/')[-1] == inst_key:
+                    logger.info(f'{path} {raw[path]}')
             raise InstitutionAttrsMismatchError(inst_key)
         ret[inst_key] = attrs
     return ret
@@ -191,6 +200,7 @@ def main():
     parser_list.set_defaults(func=list_insts)
     parser_list_flat = subparsers.add_parser('list-name', help='list institutions by name only')
     parser_list_flat.add_argument('--experiment', help='experiment name')
+    parser_list_flat.add_argument('--attr', dest='attr_whitelist', action='append', help='attribute names to compare (one per arg)')
     parser_list_flat.set_defaults(func=list_insts_flat)
     parser_info = subparsers.add_parser('info', help='institution info')
     parser_info.add_argument('experiment', help='experiment name')

--- a/krs/institutions.py
+++ b/krs/institutions.py
@@ -62,13 +62,14 @@ async def list_insts(experiment=None, filter_func=None, rest_client=None):
 class InstitutionAttrsMismatchError(RuntimeError):
     pass
 
-async def list_insts_flat(experiment=None, filter_func=None, attr_whitelist=None, rest_client=None):
+async def list_insts_flat(experiment=None, filter_func=None, remove_empty=True, attr_whitelist=None, rest_client=None):
     """
     List institution names in Keycloak, removing overlaps from multiple experiments.
 
     Args:
         experiment (str): experiment name (default: list all experiments)
         filter_func (callable): given a group path and set of attrs, a callable to return true/false
+        remove_empty (bool): remove institutions with no attributes
         attr_whitelist (iterable): whitelist of attributes (default: all)
 
     Returns:
@@ -79,7 +80,7 @@ async def list_insts_flat(experiment=None, filter_func=None, attr_whitelist=None
     for path in raw:
         inst_key = path.split('/')[-1]
         attrs = raw[path]
-        if not attrs:
+        if remove_empty and not attrs:
             logger.info(f'ignoring inst {path} with no attrs')
             continue
         if attr_whitelist:

--- a/krs/token.py
+++ b/krs/token.py
@@ -56,6 +56,7 @@ def main():
     parser_get.add_argument('url', help='keycloak base url')
     parser_get.add_argument('client_id', help='keycloak client id')
     parser_get.add_argument('client_secret', help='keycloak client secret')
+    parser_get.add_argument('--client_realm', default='master', help='keycloak client realm')
     parser_get.set_defaults(func=get_token)
     args = vars(parser.parse_args())
 

--- a/tests/krs/test_institutions.py
+++ b/tests/krs/test_institutions.py
@@ -66,7 +66,7 @@ async def test_list_insts_flat_whitelist(keycloak_bootstrap):
     with pytest.raises(institutions.InstitutionAttrsMismatchError):
         await institutions.list_insts_flat(rest_client=keycloak_bootstrap)
     ret = await institutions.list_insts_flat(attr_whitelist=['foo'], rest_client=keycloak_bootstrap)
-    assert ret == {'Test': {'foo': 'bar'}, 'Test2': {'bar': 'baz'}}
+    assert ret == {'Test': {'foo': 'bar'}, 'Test2': {}}
 
 @pytest.mark.asyncio
 async def test_list_insts_filter(keycloak_bootstrap):

--- a/tests/krs/test_institutions.py
+++ b/tests/krs/test_institutions.py
@@ -37,18 +37,36 @@ async def test_list_insts_flat(keycloak_bootstrap):
     await groups.create_group('/institutions/IceCube2', rest_client=keycloak_bootstrap)
     await groups.create_group('/institutions/IceCube2/Test', rest_client=keycloak_bootstrap)
     await groups.create_group('/institutions/IceCube2/Test2', rest_client=keycloak_bootstrap)
-    ret = await institutions.list_insts_flat(rest_client=keycloak_bootstrap)
+    ret = await institutions.list_insts_flat(remove_empty=False, rest_client=keycloak_bootstrap)
     assert ret == {'Test': {}, 'Test2': {}}
 
-    ret = await institutions.list_insts_flat('IceCube', rest_client=keycloak_bootstrap)
+    ret = await institutions.list_insts_flat('IceCube', remove_empty=False, rest_client=keycloak_bootstrap)
     assert ret == {'Test': {}}
 
-    ret = await institutions.list_insts_flat('Other', rest_client=keycloak_bootstrap)
+    ret = await institutions.list_insts_flat('Other', remove_empty=False, rest_client=keycloak_bootstrap)
     assert ret == {}
 
     await groups.create_group('/institutions/IceCube/Test2', {'foo': 'bar'}, rest_client=keycloak_bootstrap)
     with pytest.raises(institutions.InstitutionAttrsMismatchError):
+        await institutions.list_insts_flat(remove_empty=False, rest_client=keycloak_bootstrap)
+
+@pytest.mark.asyncio
+async def test_list_insts_flat_whitelist(keycloak_bootstrap):
+    await groups.create_group('/institutions', rest_client=keycloak_bootstrap)
+
+    await groups.create_group('/institutions/IceCube', rest_client=keycloak_bootstrap)
+    await groups.create_group('/institutions/IceCube/Test', {'foo': 'bar'}, rest_client=keycloak_bootstrap)
+    await groups.create_group('/institutions/IceCube2', rest_client=keycloak_bootstrap)
+    await groups.create_group('/institutions/IceCube2/Test', {'foo': 'bar'}, rest_client=keycloak_bootstrap)
+    ret = await institutions.list_insts_flat(rest_client=keycloak_bootstrap)
+    assert ret == {'Test': {'foo': 'bar'}}
+
+    await groups.create_group('/institutions/IceCube/Test2', {'bar': 'baz'}, rest_client=keycloak_bootstrap)
+    await groups.create_group('/institutions/IceCube2/Test2', {'bar': 'foo'}, rest_client=keycloak_bootstrap)
+    with pytest.raises(institutions.InstitutionAttrsMismatchError):
         await institutions.list_insts_flat(rest_client=keycloak_bootstrap)
+    ret = await institutions.list_insts_flat(attr_whitelist=['foo'], rest_client=keycloak_bootstrap)
+    assert ret == {'Test': {'foo': 'bar'}, 'Test2': {'bar': 'baz'}}
 
 @pytest.mark.asyncio
 async def test_list_insts_filter(keycloak_bootstrap):


### PR DESCRIPTION
Allows a successful run with 
```
python -m krs.institutions list-name --attr has_mou --attr cite --attr name --attr abbreviation --attr region --attr is_US --attr institutionLeadUid
```