### PR TITLE
Canonical address

### DIFF
--- a/actions/create_email_account.py
+++ b/actions/create_email_account.py
@@ -36,12 +36,12 @@ async def process(email_server, group_path, dryrun=False, keycloak_client=None):
         if (not user['firstName']) or (not user['lastName']):
             logger.debug(f'user {username} does not have a valid first and last name, skipping')
             continue
-        if 'canonical_address' not in attrs:
-            logger.debug(f'user {username} does not have canonical_address attribute, skipping')
+        if 'canonical_email' not in attrs:
+            logger.debug(f'user {username} does not have canonical_email attribute, skipping')
             continue
 
         users[username] = {
-            'canonical': attrs['canonical_address'].split('@')[0],
+            'canonical': attrs['canonical_email'].split('@')[0],
             'uid': int(attrs['uidNumber']),
             'gid': int(attrs['gidNumber']),
         }

--- a/actions/create_email_account.py
+++ b/actions/create_email_account.py
@@ -36,6 +36,10 @@ async def process(email_server, group_path, dryrun=False, keycloak_client=None):
         if (not user['firstName']) or (not user['lastName']):
             logger.debug(f'user {username} does not have a valid first and last name, skipping')
             continue
+        if 'canonical_address' not in attrs:
+            logger.debug(f'user {username} does not have canonical_address attribute, skipping')
+            continue
+
         users[username] = {
             'canonical': attrs['canonical_address'].split('@')[0],
             'uid': int(attrs['uidNumber']),

--- a/actions/create_email_account.py
+++ b/actions/create_email_account.py
@@ -10,7 +10,6 @@ Example::
 import logging
 import asyncio
 import json
-import unidecode
 
 from krs.groups import get_group_membership
 from krs.users import list_users
@@ -37,9 +36,8 @@ async def process(email_server, group_path, dryrun=False, keycloak_client=None):
         if (not user['firstName']) or (not user['lastName']):
             logger.debug(f'user {username} does not have a valid first and last name, skipping')
             continue
-        canonical = unidecode.unidecode(user['firstName'].lower()+'.'+user['lastName'].lower()).replace(' ', '')
         users[username] = {
-            'canonical': canonical,
+            'canonical': attrs['canonical_address'].split('@')[0],
             'uid': int(attrs['uidNumber']),
             'gid': int(attrs['gidNumber']),
         }

--- a/krs/users.py
+++ b/krs/users.py
@@ -89,7 +89,7 @@ async def create_user(username, first_name, last_name, email, attribs=None, rest
     """
     if not attribs:
         attribs = {}
-    attribs['canonical_address'] = unidecode(first_name + '.' + last_name).lower().replace(' ', '.') + "@icecube.wisc.edu"
+    attribs['canonical_email'] = unidecode(first_name + '.' + last_name).lower().replace(' ', '.') + "@icecube.wisc.edu"
 
     try:
         await user_info(username, rest_client=rest_client)

--- a/krs/users.py
+++ b/krs/users.py
@@ -3,6 +3,7 @@ User actions against Keycloak.
 """
 import asyncio
 import logging
+from unidecode import unidecode
 
 import requests.exceptions
 
@@ -88,6 +89,7 @@ async def create_user(username, first_name, last_name, email, attribs=None, rest
     """
     if not attribs:
         attribs = {}
+    attribs['canonical_address'] = unidecode(first_name + '.' + last_name).lower().replace(' ', '.') + "@icecube.wisc.edu"
 
     try:
         await user_info(username, rest_client=rest_client)

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -79,7 +79,7 @@ pypng==0.20220715.0
     # via qrcode
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.28.2
+requests==2.29.0
     # via
     #   google-api-core
     #   requests-futures
@@ -97,7 +97,7 @@ six==1.16.0
     # via
     #   google-auth
     #   google-auth-httplib2
-tornado==6.3
+tornado==6.3.1
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
@@ -117,7 +117,7 @@ wipac-dev-tools==1.6.15
     #   wipac-rest-tools
 wipac-rest-tools==1.4.18
     # via wipac-keycloak-rest-services (setup.py)
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aio-pika
     #   aiormq

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -16,7 +16,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-coverage[toml]==7.2.3
+coverage[toml]==7.2.4
     # via
     #   pytest-cov
     #   wipac-keycloak-rest-services (setup.py)

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -76,7 +76,7 @@ pytest-mock==3.10.0
     # via wipac-keycloak-rest-services (setup.py)
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.28.2
+requests==2.29.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -88,7 +88,7 @@ tomli==2.0.1
     # via
     #   coverage
     #   pytest
-tornado==6.3
+tornado==6.3.1
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
@@ -104,7 +104,7 @@ wipac-dev-tools==1.6.15
     #   wipac-rest-tools
 wipac-rest-tools==1.4.18
     # via wipac-keycloak-rest-services (setup.py)
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aio-pika
     #   aiormq

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -16,7 +16,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-coverage[toml]==7.2.4
+coverage[toml]==7.2.5
     # via
     #   pytest-cov
     #   wipac-keycloak-rest-services (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,7 +44,7 @@ pypng==0.20220715.0
     # via qrcode
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.28.2
+requests==2.29.0
     # via
     #   requests-futures
     #   wipac-dev-tools
@@ -52,7 +52,7 @@ requests==2.28.2
     #   wipac-rest-tools
 requests-futures==1.0.0
     # via wipac-rest-tools
-tornado==6.3
+tornado==6.3.1
     # via wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
@@ -68,7 +68,7 @@ wipac-dev-tools==1.6.15
     #   wipac-rest-tools
 wipac-rest-tools==1.4.18
     # via wipac-keycloak-rest-services (setup.py)
-yarl==1.8.2
+yarl==1.9.2
     # via
     #   aio-pika
     #   aiormq

--- a/tests/actions/test_create_email_account.py
+++ b/tests/actions/test_create_email_account.py
@@ -51,20 +51,6 @@ async def test_create_not_in_group(keycloak_bootstrap, patch_ssh_sudo):
     user_dict = {}
     assert json.loads(patch_ssh_sudo.call_args.args[1].split('\n')[6].split('=',1)[-1]) == user_dict
 
-@pytest.mark.asyncio
-async def test_create_unicode(keycloak_bootstrap, patch_ssh_sudo):
-    await users.create_user('foo', first_name='First', last_name='Mü Last', email='foo@test', attribs={'uidNumber':1000, 'gidNumber':1000}, rest_client=keycloak_bootstrap)
-    await groups.create_group('/email', rest_client=keycloak_bootstrap)
-    await groups.add_user_group('/email', 'foo', rest_client=keycloak_bootstrap)
-
-    await create_email_account.process('test.test.test', '/email', keycloak_client=keycloak_bootstrap)
-
-    patch_ssh_sudo.assert_called_once()
-    assert patch_ssh_sudo.call_args.args[0] == 'test.test.test'
-
-    user_dict = {'foo': {'canonical': 'first.mulast', 'uid': 1000, 'gid': 1000}}
-    assert json.loads(patch_ssh_sudo.call_args.args[1].split('\n')[6].split('=',1)[-1]) == user_dict
-
 
 @pytest_asyncio.fixture
 async def listener(keycloak_bootstrap, rabbitmq_bootstrap, tmp_path):

--- a/tests/krs/test_users.py
+++ b/tests/krs/test_users.py
@@ -29,7 +29,9 @@ async def test_user_info(keycloak_bootstrap):
 
 @pytest.mark.asyncio
 async def test_create_user(keycloak_bootstrap):
-    await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', rest_client=keycloak_bootstrap)
+    await users.create_user('testuser', first_name='Fĭrst', last_name='Mü Lăst', email='foo@test', rest_client=keycloak_bootstrap)
+    ret = await users.user_info('testuser', rest_client=keycloak_bootstrap)
+    assert ret['attributes'] == {'canonical_address': 'first.mu.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
 async def test_modify_user(keycloak_bootstrap):
@@ -77,14 +79,14 @@ async def test_modify_user_existing_attr(keycloak_bootstrap):
     await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', attribs={'foo': 'bar'}, rest_client=keycloak_bootstrap)
     await users.modify_user('testuser', attribs={'baz': 'foo'}, rest_client=keycloak_bootstrap)
     ret = await users.user_info('testuser', rest_client=keycloak_bootstrap)
-    assert ret['attributes'] == {'foo': 'bar', 'baz': 'foo'}
+    assert ret['attributes'] == {'foo': 'bar', 'baz': 'foo', 'canonical_address': 'first.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
 async def test_modify_user_del_attr(keycloak_bootstrap):
     await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', attribs={'foo': 'bar'}, rest_client=keycloak_bootstrap)
     await users.modify_user('testuser', attribs={'foo': None, 'baz': 'foo'}, rest_client=keycloak_bootstrap)
     ret = await users.user_info('testuser', rest_client=keycloak_bootstrap)
-    assert ret['attributes'] == {'baz': 'foo'}
+    assert ret['attributes'] == {'baz': 'foo', 'canonical_address': 'first.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
 async def test_set_user_password(keycloak_bootstrap):

--- a/tests/krs/test_users.py
+++ b/tests/krs/test_users.py
@@ -31,7 +31,7 @@ async def test_user_info(keycloak_bootstrap):
 async def test_create_user(keycloak_bootstrap):
     await users.create_user('testuser', first_name='Fĭrst', last_name='Mü Lăst', email='foo@test', rest_client=keycloak_bootstrap)
     ret = await users.user_info('testuser', rest_client=keycloak_bootstrap)
-    assert ret['attributes'] == {'canonical_address': 'first.mu.last@icecube.wisc.edu'}
+    assert ret['attributes'] == {'canonical_email': 'first.mu.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
 async def test_modify_user(keycloak_bootstrap):
@@ -79,14 +79,14 @@ async def test_modify_user_existing_attr(keycloak_bootstrap):
     await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', attribs={'foo': 'bar'}, rest_client=keycloak_bootstrap)
     await users.modify_user('testuser', attribs={'baz': 'foo'}, rest_client=keycloak_bootstrap)
     ret = await users.user_info('testuser', rest_client=keycloak_bootstrap)
-    assert ret['attributes'] == {'foo': 'bar', 'baz': 'foo', 'canonical_address': 'first.last@icecube.wisc.edu'}
+    assert ret['attributes'] == {'foo': 'bar', 'baz': 'foo', 'canonical_email': 'first.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
 async def test_modify_user_del_attr(keycloak_bootstrap):
     await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', attribs={'foo': 'bar'}, rest_client=keycloak_bootstrap)
     await users.modify_user('testuser', attribs={'foo': None, 'baz': 'foo'}, rest_client=keycloak_bootstrap)
     ret = await users.user_info('testuser', rest_client=keycloak_bootstrap)
-    assert ret['attributes'] == {'baz': 'foo', 'canonical_address': 'first.last@icecube.wisc.edu'}
+    assert ret['attributes'] == {'baz': 'foo', 'canonical_email': 'first.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
 async def test_set_user_password(keycloak_bootstrap):


### PR DESCRIPTION
Implementation of `canonical_address` attribute.

This adds `canonical_address` to all new accounts and doesn't allow custom `canonical_addres`es