### PR TITLE
Detect institutionless users

### DIFF
--- a/actions/update_institutionless_users.py
+++ b/actions/update_institutionless_users.py
@@ -1,0 +1,77 @@
+"""
+Manage the institutionless_since attribute of keycloak users:
+- If a user does not belong to any institution group and does not already have the
+    institutionless_since attribute, create and set it to current time.
+- If a user belongs to an institution group and has the institutionless_since
+    attribute defined, delete this attribute.
+
+Example::
+    python -m actions.update_institutionless_users
+"""
+import asyncio
+import logging
+from datetime import datetime
+
+from krs.token import get_rest_client
+from krs.groups import get_group_membership
+from krs.institutions import list_insts
+from krs.users import list_users, modify_user
+
+logger = logging.getLogger('update_institutionless_users')
+
+
+async def update_institutionless_users(keycloak_client, dryrun=False):
+    """Manage the institutionless_since attribute based on users' institution membership.
+
+    Users that belong to an institution group should not have institutionless_since
+      attribute. Users that don't belong to any institution should have
+      institutionless_since set to the time when it was first detected that they
+      are institutionless. The timestamp should be a string in ISO 8601 format.
+
+    Args
+        keycloak_client (OpenIDRestClient): REST client to the KeyCloak server
+        dryrun (bool): perform a trial run with no changes made
+    """
+    all_users = await list_users(rest_client=keycloak_client)
+
+    institutions = await list_insts(rest_client=keycloak_client)
+    institutioned_usernames = set()  # i.e. users that belong to an institution
+    for inst_path in institutions.keys():
+        inst_usernames = await get_group_membership(inst_path, rest_client=keycloak_client)
+        institutioned_usernames.update(inst_usernames)
+
+    for username in institutioned_usernames:
+        if 'institutionless_since' in all_users[username]['attributes']:
+            logger.info(f'Removing "institutionless_since" attribute from {username} (dryrun={dryrun})')
+            if not dryrun:
+                await modify_user(username, attribs={'institutionless_since': None}, rest_client=keycloak_client)
+
+    now = datetime.now().isoformat()
+    institutionless_usernames = set(all_users) - institutioned_usernames
+    for username in institutionless_usernames:
+        if 'institutionless_since' not in all_users[username]['attributes']:
+            logger.info(f'Setting "institutionless_since" attribute of {username} (dryrun={dryrun})')
+            if not dryrun:
+                await modify_user(username, attribs={'institutionless_since': now}, rest_client=keycloak_client)
+
+
+def main():
+    import argparse
+    parser = argparse.ArgumentParser(
+        description='Manage the "institutionless_since" user attribute. '
+                    'See file docstring for details.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('--dryrun', action='store_true', help='dry run')
+    parser.add_argument('--log-level', default='info',
+                        choices=('debug', 'info', 'warning', 'error'), help='logging level')
+
+    args = vars(parser.parse_args())
+
+    logging.basicConfig(level=getattr(logging, args['log_level'].upper()))
+
+    keycloak_client = get_rest_client()
+    asyncio.run(update_institutionless_users(keycloak_client, args['dryrun']))
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=actions --output-file=requirements-actions.txt
 #
-aio-pika==9.0.7
+aio-pika==9.1.4
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
@@ -18,15 +18,15 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==41.0.0
+cryptography==41.0.1
     # via pyjwt
 dnspython==2.3.0
     # via pymongo
-google-api-core==2.11.0
+google-api-core==2.11.1
     # via google-api-python-client
-google-api-python-client==2.88.0
+google-api-python-client==2.92.0
     # via wipac-keycloak-rest-services (setup.py)
-google-auth==2.19.0
+google-auth==2.21.0
     # via
     #   google-api-core
     #   google-api-python-client
@@ -36,7 +36,7 @@ google-auth-httplib2==0.1.0
     # via google-api-python-client
 google-auth-oauthlib==1.0.0
     # via wipac-keycloak-rest-services (setup.py)
-googleapis-common-protos==1.59.0
+googleapis-common-protos==1.59.1
     # via google-api-core
 httplib2==0.22.0
     # via
@@ -48,7 +48,7 @@ idna==3.4
     #   yarl
 ldap3==2.9.1
     # via wipac-keycloak-rest-services (setup.py)
-motor==3.1.2
+motor==3.2.0
     # via wipac-keycloak-rest-services (setup.py)
 multidict==6.0.4
     # via yarl
@@ -56,7 +56,7 @@ oauthlib==3.2.2
     # via requests-oauthlib
 pamqp==3.2.1
     # via aiormq
-protobuf==4.23.2
+protobuf==4.23.4
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -71,9 +71,9 @@ pycparser==2.21
     # via cffi
 pyjwt[crypto]==2.7.0
     # via wipac-rest-tools
-pymongo==4.3.3
+pymongo==4.4.0
     # via motor
-pyparsing==3.0.9
+pyparsing==3.1.0
     # via httplib2
 pypng==0.20220715.0
     # via qrcode
@@ -87,7 +87,7 @@ requests==2.31.0
     #   wipac-dev-tools
     #   wipac-keycloak-rest-services (setup.py)
     #   wipac-rest-tools
-requests-futures==1.0.0
+requests-futures==1.0.1
     # via wipac-rest-tools
 requests-oauthlib==1.3.1
     # via google-auth-oauthlib
@@ -99,7 +99,7 @@ six==1.16.0
     #   google-auth-httplib2
 tornado==6.3.2
     # via wipac-rest-tools
-typing-extensions==4.6.2
+typing-extensions==4.7.1
     # via
     #   qrcode
     #   wipac-dev-tools

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=tests --output-file=requirements-tests.txt
 #
-aio-pika==9.0.7
+aio-pika==9.1.4
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
@@ -20,11 +20,11 @@ coverage[toml]==7.2.7
     # via
     #   pytest-cov
     #   wipac-keycloak-rest-services (setup.py)
-cryptography==41.0.0
+cryptography==41.0.1
     # via pyjwt
 dnspython==2.3.0
     # via pymongo
-exceptiongroup==1.1.1
+exceptiongroup==1.1.2
     # via pytest
 flake8==6.0.0
     # via wipac-keycloak-rest-services (setup.py)
@@ -38,7 +38,7 @@ ldap3==2.9.1
     # via wipac-keycloak-rest-services (setup.py)
 mccabe==0.7.0
     # via flake8
-motor==3.1.2
+motor==3.2.0
     # via wipac-keycloak-rest-services (setup.py)
 multidict==6.0.4
     # via yarl
@@ -46,7 +46,7 @@ packaging==23.1
     # via pytest
 pamqp==3.2.1
     # via aiormq
-pluggy==1.0.0
+pluggy==1.2.0
     # via pytest
 pyasn1==0.5.0
     # via ldap3
@@ -58,11 +58,11 @@ pyflakes==3.0.1
     # via flake8
 pyjwt[crypto]==2.7.0
     # via wipac-rest-tools
-pymongo==4.3.3
+pymongo==4.4.0
     # via motor
 pypng==0.20220715.0
     # via qrcode
-pytest==7.3.1
+pytest==7.4.0
     # via
     #   pytest-asyncio
     #   pytest-cov
@@ -72,7 +72,7 @@ pytest-asyncio==0.21.0
     # via wipac-keycloak-rest-services (setup.py)
 pytest-cov==4.1.0
     # via wipac-keycloak-rest-services (setup.py)
-pytest-mock==3.10.0
+pytest-mock==3.11.1
     # via wipac-keycloak-rest-services (setup.py)
 qrcode==7.4.2
     # via wipac-rest-tools
@@ -82,7 +82,7 @@ requests==2.31.0
     #   wipac-dev-tools
     #   wipac-keycloak-rest-services (setup.py)
     #   wipac-rest-tools
-requests-futures==1.0.0
+requests-futures==1.0.1
     # via wipac-rest-tools
 tomli==2.0.1
     # via
@@ -90,11 +90,11 @@ tomli==2.0.1
     #   pytest
 tornado==6.3.2
     # via wipac-rest-tools
-typing-extensions==4.6.2
+typing-extensions==4.7.1
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
 wipac-dev-tools==1.6.16
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-aio-pika==9.0.7
+aio-pika==9.1.4
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
@@ -16,7 +16,7 @@ cffi==1.15.1
     # via cryptography
 charset-normalizer==3.1.0
     # via requests
-cryptography==41.0.0
+cryptography==41.0.1
     # via pyjwt
 dnspython==2.3.0
     # via pymongo
@@ -26,7 +26,7 @@ idna==3.4
     #   yarl
 ldap3==2.9.1
     # via wipac-keycloak-rest-services (setup.py)
-motor==3.1.2
+motor==3.2.0
     # via wipac-keycloak-rest-services (setup.py)
 multidict==6.0.4
     # via yarl
@@ -38,7 +38,7 @@ pycparser==2.21
     # via cffi
 pyjwt[crypto]==2.7.0
     # via wipac-rest-tools
-pymongo==4.3.3
+pymongo==4.4.0
     # via motor
 pypng==0.20220715.0
     # via qrcode
@@ -50,15 +50,15 @@ requests==2.31.0
     #   wipac-dev-tools
     #   wipac-keycloak-rest-services (setup.py)
     #   wipac-rest-tools
-requests-futures==1.0.0
+requests-futures==1.0.1
     # via wipac-rest-tools
 tornado==6.3.2
     # via wipac-rest-tools
-typing-extensions==4.6.2
+typing-extensions==4.7.1
     # via
     #   qrcode
     #   wipac-dev-tools
-urllib3==2.0.2
+urllib3==2.0.3
     # via requests
 wipac-dev-tools==1.6.16
     # via

--- a/tests/actions/test_update_institutionless_users.py
+++ b/tests/actions/test_update_institutionless_users.py
@@ -1,0 +1,45 @@
+import pytest
+
+from krs import users, groups, institutions
+from ..util import keycloak_bootstrap
+
+from actions.update_institutionless_users import update_institutionless_users
+
+
+@pytest.mark.asyncio
+async def test_update_institutionless_users(keycloak_bootstrap):
+    await groups.create_group('/institutions', rest_client=keycloak_bootstrap)
+    await groups.create_group('/institutions/IceCube', rest_client=keycloak_bootstrap)
+    attrs = {'name': 'Test', 'cite': 'Test', 'abbreviation': 'T', 'is_US': False,
+             'region': institutions.Region.NORTH_AMERICA}
+    await institutions.create_inst('IceCube', 'Test', attrs, rest_client=keycloak_bootstrap)
+
+    await users.create_user('institutioned-no-changes', first_name='F', last_name='L', email='a@test',
+                            attribs={'uidNumber':1000, 'gidNumber':1000}, rest_client=keycloak_bootstrap)
+    await groups.add_user_group('/institutions/IceCube/Test', 'institutioned-no-changes', rest_client=keycloak_bootstrap)
+
+    await users.create_user('institutionless-no-changes', first_name='F', last_name='L', email='b@test',
+                            attribs={'uidNumber':1001, 'gidNumber':1001,
+                                     'institutionless_since':'2023-07-07T13:07:56.400437'}, rest_client=keycloak_bootstrap)
+
+    await users.create_user('make-institutioned', first_name='F', last_name='L', email='c@test',
+                            attribs={'uidNumber':1002, 'gidNumber':1002,
+                                     'institutionless_since':'2023-07-07T13:07:56.400437'}, rest_client=keycloak_bootstrap)
+    await groups.add_user_group('/institutions/IceCube/Test', 'make-institutioned', rest_client=keycloak_bootstrap)
+
+    await users.create_user('make-institutionless', first_name='F', last_name='L', email='d@test',
+                            attribs={'uidNumber':1003, 'gidNumber':1003}, rest_client=keycloak_bootstrap)
+
+    await update_institutionless_users(keycloak_client=keycloak_bootstrap)
+
+    ret = await users.user_info('institutioned-no-changes', rest_client=keycloak_bootstrap)
+    assert 'institutionless_since' not in ret['attributes']
+
+    ret = await users.user_info('institutionless-no-changes', rest_client=keycloak_bootstrap)
+    assert ret['attributes']['institutionless_since'] == '2023-07-07T13:07:56.400437'
+
+    ret = await users.user_info('make-institutioned', rest_client=keycloak_bootstrap)
+    assert 'institutionless_since' not in ret['attributes']
+
+    ret = await users.user_info('make-institutionless', rest_client=keycloak_bootstrap)
+    assert 'institutionless_since' in ret['attributes']


### PR DESCRIPTION
New action to add `institutionless_since` attribute to users that do not belong to any institution (and to delete this attribute if a user does belong to an institution group).

This will later be used for deprovisioning actions