### PR TITLE
talk to old servers via ssh-rsa, like i3mail

### DIFF
--- a/actions/util.py
+++ b/actions/util.py
@@ -27,7 +27,12 @@ INGORE_DIR_ROLES = {
     '/mnt/lfs7/user_test': {'roleAccount', 'appAccount', 'thirdPartyAccount'},
 }
 
-ssh_opts = ['-o', 'UserKnownHostsFile=/dev/null', '-o', 'StrictHostKeyChecking=no']
+ssh_opts = [
+    '-o', 'UserKnownHostsFile=/dev/null',
+    '-o', 'StrictHostKeyChecking=no',
+    '-o', 'HostKeyAlgorithms=+ssh-rsa',
+    '-o', 'PubkeyAcceptedAlgorithms=+ssh-rsa',
+]
 
 
 def ssh(host, *args):

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -8,20 +8,26 @@ aio-pika==9.1.4
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
+anyio==3.7.1
+    # via httpcore
 cachetools==5.3.1
     # via
     #   google-auth
     #   wipac-rest-tools
 certifi==2023.5.7
-    # via requests
+    # via
+    #   httpcore
+    #   requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
 cryptography==41.0.2
     # via pyjwt
-dnspython==2.3.0
+dnspython==2.4.0
     # via pymongo
+exceptiongroup==1.1.2
+    # via anyio
 google-api-core==2.11.1
     # via google-api-python-client
 google-api-python-client==2.93.0
@@ -38,12 +44,17 @@ google-auth-oauthlib==1.0.0
     # via wipac-keycloak-rest-services (setup.py)
 googleapis-common-protos==1.59.1
     # via google-api-core
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.3
+    # via dnspython
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
 idna==3.4
     # via
+    #   anyio
     #   requests
     #   yarl
 ldap3==2.9.1
@@ -97,6 +108,11 @@ six==1.16.0
     # via
     #   google-auth
     #   google-auth-httplib2
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   dnspython
+    #   httpcore
 tornado==6.3.2
     # via wipac-rest-tools
 typing-extensions==4.7.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -8,10 +8,14 @@ aio-pika==9.1.4
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
+anyio==3.7.1
+    # via httpcore
 cachetools==5.3.1
     # via wipac-rest-tools
 certifi==2023.5.7
-    # via requests
+    # via
+    #   httpcore
+    #   requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
@@ -22,14 +26,21 @@ coverage[toml]==7.2.7
     #   wipac-keycloak-rest-services (setup.py)
 cryptography==41.0.2
     # via pyjwt
-dnspython==2.3.0
+dnspython==2.4.0
     # via pymongo
 exceptiongroup==1.1.2
-    # via pytest
+    # via
+    #   anyio
+    #   pytest
 flake8==6.0.0
     # via wipac-keycloak-rest-services (setup.py)
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.3
+    # via dnspython
 idna==3.4
     # via
+    #   anyio
     #   requests
     #   yarl
 iniconfig==2.0.0
@@ -84,6 +95,11 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   dnspython
+    #   httpcore
 tomli==2.0.1
     # via
     #   coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,20 +8,31 @@ aio-pika==9.1.4
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
+anyio==3.7.1
+    # via httpcore
 cachetools==5.3.1
     # via wipac-rest-tools
 certifi==2023.5.7
-    # via requests
+    # via
+    #   httpcore
+    #   requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
 cryptography==41.0.2
     # via pyjwt
-dnspython==2.3.0
+dnspython==2.4.0
     # via pymongo
+exceptiongroup==1.1.2
+    # via anyio
+h11==0.14.0
+    # via httpcore
+httpcore==0.17.3
+    # via dnspython
 idna==3.4
     # via
+    #   anyio
     #   requests
     #   yarl
 ldap3==2.9.1
@@ -52,6 +63,11 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
+sniffio==1.3.0
+    # via
+    #   anyio
+    #   dnspython
+    #   httpcore
 tornado==6.3.2
     # via wipac-rest-tools
 typing-extensions==4.7.1


### PR DESCRIPTION
For a while now new email accounts weren't getting created.  ssh/scp was failing, likely because the container image is now new enough to disable the ssh-rsa algorithm by default.  This turns it back on.

Looks like this has probably been broken since 1.4.0 in February.  It only got deployed to prod on
`Mon Jul 10 11:50:01 CDT 2023`.