### PR TITLE
make sync_gws_mailing_lists support group member roles

### DIFF
--- a/actions/sync_gws_mailing_lists.py
+++ b/actions/sync_gws_mailing_lists.py
@@ -79,8 +79,8 @@ async def get_kc_group_canonical_emails(group_path, keycloak_client):
 def sync_gws_group_role(group_email, role, role_emails, gws_members_client, dryrun):
     """Sync Google Workspace group members of the given role to the given email list """
     group_members = get_gws_group_members(group_email, gws_members_client)
-    initial_this_role_emails = [m['email'] for m in group_members if m['role'] == role]
-    initial_other_roles_emails = [m['email'] for m in group_members if m['role'] != role]
+    initial_this_role_emails = {m['email'] for m in group_members if m['role'] == role}
+    initial_other_roles_emails = {m['email'] for m in group_members if m['role'] != role}
     for email in role_emails:
         if email in initial_this_role_emails:
             continue
@@ -94,7 +94,7 @@ def sync_gws_group_role(group_email, role, role_emails, gws_members_client, dryr
             if not dryrun:
                 gws_members_client.insert(groupKey=group_email, body=body).execute()
 
-    for email in set(initial_this_role_emails) - set(role_emails):
+    for email in initial_this_role_emails - set(role_emails):
         logger.info(f"Removing {email} from {group_email} (dryrun={dryrun})")
         if not dryrun:
             gws_members_client.delete(groupKey=group_email, memberKey=email).execute()

--- a/actions/sync_gws_mailing_lists.py
+++ b/actions/sync_gws_mailing_lists.py
@@ -3,11 +3,14 @@ Synchronize memberships of Google Workspace groups to their corresponding
 Keycloak mailing list groups. Users are subscribed to Google Workspace groups
 using their KeyCloak `canonical_email` attribute.
 
+Only group members whose role is 'MANAGER' or 'MEMBER' are managed. Nothing
+is done with the 'OWNER' members (it's assumed these are managed out of band).
+
 Keycloak mailing list groups are the subgroups of /mail. Each group must
 have attribute `email` that will be used to map it to a Google Workspace
 group.
 
-KeyCloak client is configured using environment variables. See krs/token.py
+KeyCloak client can be configured using environment variables. See krs/token.py
 for details.
 
 Domain-wide delegation must be enabled for the service account. See code
@@ -32,23 +35,78 @@ from krs.users import user_info
 logger = logging.getLogger('sync_gws_mailing_lists')
 
 
-def get_all_group_members(group_email, gws_members_client):
-    """Get email addresses of all members of a Google Workspace members"""
+class GroupDoesNotExist(Exception):
+    pass
+
+
+def get_gws_group_members(group_email, gws_members_client) -> list:
+    """Return a list of Google Workspace group member dicts.
+
+    Specification of group member dictionary is here:
+    https://developers.google.com/admin-sdk/directory/reference/rest/v1/members#Member
+
+    Args:
+        group_email (str): Google Workspace group email
+        gws_members_client (googleapiclient.discovery.Resource): Admin API Members resource
+
+    Returns:
+        list: list of member dicts
+    """
+    ret = []
     req = gws_members_client.list(groupKey=group_email)
-    members = []
     while req is not None:
         res = req.execute()
         if 'members' in res:
-            members.extend(m['email'] for m in res['members'])
-        else:
-            break
+            ret.extend(res['members'])
         req = gws_members_client.list_next(req, res)
-    return members
+    return ret
 
 
-async def sync_gws_mailing_lists(gws_members_client, keycloak_client, dryrun=False):
+async def get_kc_group_canonical_emails(group_path, keycloak_client):
+    """Return a list of canonical emails of members of a KeyCloak group."""
+    try:
+        usernames = await get_group_membership(group_path, rest_client=keycloak_client)
+    except Exception as e:
+        if 'does not exist' in e.args[0]:
+            raise GroupDoesNotExist
+        else:
+            raise
+    users = [await user_info(u, rest_client=keycloak_client) for u in usernames]
+    emails = [u['attributes']['canonical_email'] for u in users]
+    return emails
+
+
+def sync_gws_group_role(group_email, role, role_emails, gws_members_client, dryrun):
+    """Sync Google Workspace group members of the given role to the given email list """
+    group_members = get_gws_group_members(group_email, gws_members_client)
+    initial_this_role_emails = [m['email'] for m in group_members if m['role'] == role]
+    initial_other_roles_emails = [m['email'] for m in group_members if m['role'] != role]
+    for email in role_emails:
+        if email in initial_this_role_emails:
+            continue
+        body = {'email': email, 'role': role}
+        if email in initial_other_roles_emails:
+            logger.info(f"Changing {email}'s role in {group_email} to {role} (dryrun={dryrun})")
+            if not dryrun:
+                gws_members_client.patch(groupKey=group_email, memberKey=email, body=body).execute()
+        else:
+            logger.info(f"Adding {email} to {group_email} as {role} (dryrun={dryrun})")
+            if not dryrun:
+                gws_members_client.insert(groupKey=group_email, body=body).execute()
+
+    for email in set(initial_this_role_emails) - set(role_emails):
+        logger.info(f"Removing {email} from {group_email} (dryrun={dryrun})")
+        if not dryrun:
+            gws_members_client.delete(groupKey=group_email, memberKey=email).execute()
+
+
+async def sync_gws_mailing_lists(gws_members_client, gws_groups_client, keycloak, dryrun=False):
     """Synchronize memberships of Google Workspace groups to their corresponding
     Keycloak mailing list groups.
+
+    Note that only group members whose role is 'MANAGER' or 'MEMBER' are managed.
+    Nothing is done with the 'OWNER' members (it's assumed these are managed out
+    ouf band).
 
     Keycloak mailing list groups are the subgroups of /mail. Each group must
     have attribute `email` that will be used to map it to a Google Workspace
@@ -56,38 +114,37 @@ async def sync_gws_mailing_lists(gws_members_client, keycloak_client, dryrun=Fal
 
     Args:
         gws_members_client (googleapiclient.discovery.Resource): Directory API's Members resource
-        keycloak_client (OpenIDRestClient): REST client to the KeyCloak server
-
-    Returns:
-        dict: run summary for unit tests
+        gws_groups_client (googleapiclient.discovery.Resource): Directory API's Groups resource
+        keycloak (OpenIDRestClient): REST client to the KeyCloak server
+        dryrun (bool): perform a mock run with no changes made
     """
-    debug = {"added": set(), "deleted": set()}
-    ml_root_group = await group_info('/mail', keycloak_client)
-    ml_groups = [sg for sg in ml_root_group['subGroups'] if sg['name'] != '_admin']
-    for ml_group in ml_groups:
+    res = gws_groups_client.list(customer='my_customer').execute()
+    gws_group_emails = [g['email'] for g in res.get('groups', [])]
+
+    kc_ml_root_group = await group_info('/mail', rest_client=keycloak)
+    kc_ml_groups = [sg for sg in kc_ml_root_group['subGroups'] if sg['name'] != '_admin']
+    for ml_group in kc_ml_groups:
         if 'email' not in ml_group['attributes']:
-            logger.error(f"Group {ml_group['path']} doesn't have attribute 'email'")
+            logger.error(f"Group {ml_group['path']} doesn't have attribute 'email'. Skipping.")
             continue
         group_email = ml_group['attributes']['email'][0]
-        kc_usernames = await get_group_membership(ml_group['path'], rest_client=keycloak_client)
-        kc_users = [await user_info(u, rest_client=keycloak_client) for u in kc_usernames]
-        kc_emails = [u['attributes']['canonical_email'] for u in kc_users]
-        gws_emails = get_all_group_members(group_email, gws_members_client)
 
-        missing_emails = set(kc_emails) - set(gws_emails)
-        for email in missing_emails:
-            logger.info(f"Adding {email} to {group_email} (dryrun={dryrun})")
-            debug["added"].add(email)
-            if not dryrun:
-                gws_members_client.insert(groupKey=group_email, body={'email': email}).execute()
+        if group_email not in gws_group_emails:
+            logger.error(f"Group {group_email} doesn't exist in Google Workspace. Skipping.")
+            continue
 
-        unwanted_emails = set(gws_emails) - set(kc_emails)
-        for email in unwanted_emails:
-            logger.info(f"Deleting {email} from {group_email} (dryrun={dryrun})")
-            debug["deleted"].add(email)
-            if not dryrun:
-                gws_members_client.delete(groupKey=group_email, memberKey=email).execute()
-    return debug
+        try:
+            kc_admin_emails = await get_kc_group_canonical_emails(ml_group['path'] + '/_admin', keycloak)
+        except GroupDoesNotExist:
+            logger.warning(f"Group {ml_group['path']} doesn't have '_admin' subgroup.")
+            kc_admin_emails = []
+        sync_gws_group_role(group_email, 'MANAGER', kc_admin_emails, gws_members_client, dryrun)
+
+        kc_member_emails = await get_kc_group_canonical_emails(ml_group['path'], keycloak)
+        # A user may be a member of both the group and its _admin subgroup.
+        # If that's the case, we don't want to overwrite them.
+        kc_member_emails = set(kc_member_emails) - set(kc_admin_emails)
+        sync_gws_group_role(group_email, 'MEMBER', kc_member_emails, gws_members_client, dryrun)
 
 
 def main():
@@ -117,8 +174,10 @@ def main():
                 'https://www.googleapis.com/auth/admin.directory.group'])
     gws_directory = build('admin', 'directory_v1', credentials=creds, cache_discovery=False)
     gws_members_client = gws_directory.members()
+    gws_groups_client = gws_directory.groups()
 
-    asyncio.run(sync_gws_mailing_lists(gws_members_client, keycloak_client, dryrun=args['dryrun']))
+    asyncio.run(sync_gws_mailing_lists(gws_members_client, gws_groups_client,
+                                       keycloak_client, dryrun=args['dryrun']))
 
 
 if __name__ == '__main__':

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -30,7 +30,7 @@ exceptiongroup==1.1.2
     # via anyio
 google-api-core==2.11.1
     # via google-api-python-client
-google-api-python-client==2.93.0
+google-api-python-client==2.94.0
     # via wipac-keycloak-rest-services (setup.py)
 google-auth==2.22.0
     # via
@@ -80,7 +80,7 @@ pyasn1-modules==0.3.0
     # via google-auth
 pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.7.0
+pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
 pymongo==4.4.1
     # via motor

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -67,7 +67,7 @@ pycparser==2.21
     # via cffi
 pyflakes==3.0.1
     # via flake8
-pyjwt[crypto]==2.7.0
+pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
 pymongo==4.4.1
     # via motor

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ pyasn1==0.5.0
     # via ldap3
 pycparser==2.21
     # via cffi
-pyjwt[crypto]==2.7.0
+pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
 pymongo==4.4.1
     # via motor

--- a/tests/actions/test_sync_gws_mailing_lists.py
+++ b/tests/actions/test_sync_gws_mailing_lists.py
@@ -1,6 +1,6 @@
 import pytest
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from ..util import keycloak_bootstrap  # noqa: F401
 from krs.groups import create_group, modify_group, add_user_group
@@ -10,16 +10,21 @@ from actions.sync_gws_mailing_lists import sync_gws_mailing_lists
 
 
 @pytest.mark.asyncio
-async def test_sync_gws_mailing_lists(keycloak_bootstrap):  # noqa: F811
-    request = MagicMock()
-    request.execute = MagicMock(
-        return_value={'members': [{'email': 'keep.keep@icecube.wisc.edu'},
-                                  {'email': 'remove@test'}]})
+async def test_sync_gws_mailing_lists_insert(keycloak_bootstrap):  # noqa: F811
+    request_members = MagicMock()
+    request_members.execute = MagicMock(
+        return_value={'members': [
+            {'email': 'keep.keep@icecube.wisc.edu', 'role': 'MEMBER'},
+            {'email': 'owner@test', 'role': 'OWNER'}]})
     gws_members_client = MagicMock()
-    gws_members_client.list = MagicMock(return_value=request)
+    gws_members_client.list = MagicMock(return_value=request_members)
     gws_members_client.list_next = MagicMock(return_value=None)
-    gws_members_client.insert = MagicMock()
-    gws_members_client.delete = MagicMock()
+
+    request_groups = MagicMock()
+    request_groups.execute = MagicMock(
+        return_value={'groups': [{'email': 'test@gws'}]})
+    gws_groups_client = MagicMock()
+    gws_groups_client.list = MagicMock(return_value=request_groups)
 
     await create_group('/mail', rest_client=keycloak_bootstrap)
     await create_group('/mail/list', rest_client=keycloak_bootstrap)
@@ -31,12 +36,77 @@ async def test_sync_gws_mailing_lists(keycloak_bootstrap):  # noqa: F811
     await create_user('add', first_name='add', last_name='add', email='add@test', rest_client=keycloak_bootstrap)
     await add_user_group('/mail/list', 'add', rest_client=keycloak_bootstrap)
 
-    ret = await sync_gws_mailing_lists(gws_members_client, keycloak_bootstrap, dryrun=False)
+    await sync_gws_mailing_lists(gws_members_client, gws_groups_client, keycloak_bootstrap, dryrun=False)
 
-    gws_members_client.list.assert_called_once()
-    gws_members_client.list_next.assert_called_once()
-    gws_members_client.insert.assert_called_once()
-    gws_members_client.delete.assert_called_once()
-    request.execute.assert_called_once()
+    assert gws_members_client.insert.call_args_list == \
+           [call(groupKey='test@gws', body={'email': 'add.add@icecube.wisc.edu',
+                                            'role': 'MEMBER'})]
+    assert gws_members_client.delete.call_count == 0
+    assert gws_members_client.patch.call_count == 0
 
-    assert ret == {"added": {"add.add@icecube.wisc.edu"}, "deleted": {"remove@test"}}
+
+@pytest.mark.asyncio
+async def test_sync_gws_mailing_lists_delete(keycloak_bootstrap):  # noqa: F811
+    request_members = MagicMock()
+    request_members.execute = MagicMock(
+        return_value={'members': [
+            {'email': 'keep.keep@icecube.wisc.edu', 'role': 'MEMBER'},
+            {'email': 'owner@test', 'role': 'OWNER'},
+            {'email': 'remove@test', 'role': 'MEMBER'}]})
+    gws_members_client = MagicMock()
+    gws_members_client.list = MagicMock(return_value=request_members)
+    gws_members_client.list_next = MagicMock(return_value=None)
+
+    request_groups = MagicMock()
+    request_groups.execute = MagicMock(
+        return_value={'groups': [{'email': 'test@gws'}]})
+    gws_groups_client = MagicMock()
+    gws_groups_client.list = MagicMock(return_value=request_groups)
+
+    await create_group('/mail', rest_client=keycloak_bootstrap)
+    await create_group('/mail/list', rest_client=keycloak_bootstrap)
+    await modify_group('/mail/list', attrs={'email': ['test@gws']}, rest_client=keycloak_bootstrap)
+
+    await create_user('keep', first_name='keep', last_name='keep', email='keep@test', rest_client=keycloak_bootstrap)
+    await add_user_group('/mail/list', 'keep', rest_client=keycloak_bootstrap)
+
+    await sync_gws_mailing_lists(gws_members_client, gws_groups_client, keycloak_bootstrap, dryrun=False)
+
+    assert gws_members_client.delete.call_args_list == \
+        [call(groupKey='test@gws', memberKey='remove@test')]
+    assert gws_members_client.insert.call_count == 0
+    assert gws_members_client.patch.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_gws_mailing_lists_patch(keycloak_bootstrap):  # noqa: F811
+    request_members = MagicMock()
+    request_members.execute.side_effect = [
+        {'members': [{'email': 'change.role@icecube.wisc.edu', 'role': 'MEMBER'}]},
+        {'members': [{'email': 'change.role@icecube.wisc.edu', 'role': 'MANAGER'}]}]
+    gws_members_client = MagicMock()
+    gws_members_client.list = MagicMock(return_value=request_members)
+    gws_members_client.list_next = MagicMock(return_value=None)
+
+    request_groups = MagicMock()
+    request_groups.execute = MagicMock(
+        return_value={'groups': [{'email': 'test@gws'}]})
+    gws_groups_client = MagicMock()
+    gws_groups_client.list = MagicMock(return_value=request_groups)
+
+    await create_group('/mail', rest_client=keycloak_bootstrap)
+    await create_group('/mail/list', rest_client=keycloak_bootstrap)
+    await modify_group('/mail/list', attrs={'email': ['test@gws']}, rest_client=keycloak_bootstrap)
+    await create_group('/mail/list/_admin', rest_client=keycloak_bootstrap)
+
+    await create_user('change-role', first_name='change', last_name='role', email='c-r@test', rest_client=keycloak_bootstrap)
+    await add_user_group('/mail/list', 'change-role', rest_client=keycloak_bootstrap)
+    await add_user_group('/mail/list/_admin', 'change-role', rest_client=keycloak_bootstrap)
+
+    await sync_gws_mailing_lists(gws_members_client, gws_groups_client, keycloak_bootstrap, dryrun=False)
+
+    assert gws_members_client.patch.call_args_list == \
+        [call(groupKey='test@gws', memberKey='change.role@icecube.wisc.edu',
+              body={'email': 'change.role@icecube.wisc.edu', 'role': 'MANAGER'})]
+    assert gws_members_client.insert.call_count == 0
+    assert gws_members_client.delete.call_count == 0


### PR DESCRIPTION
2 differences from the previous version:

* members of _admin subgroup will be made group managers
* gws group members whose role is 'OWNER' are ignored (allows users without keycloak account like vbrik_gadm to manage group via groups.google.com)