### PR TITLE
clarify function of krs.group --new-group-path cli option

### DIFF
--- a/krs/groups.py
+++ b/krs/groups.py
@@ -105,7 +105,7 @@ async def create_group(group_path, attrs=None, rest_client=None):
         logger.info(f'group "{group_path}" created')
 
 
-async def modify_group(group_path, attrs={}, new_group_path=None, rest_client=None):
+async def modify_group(group_path, attrs={}, new_group_name=None, rest_client=None):
     """
     Modify attributes for a group.
 
@@ -116,7 +116,7 @@ async def modify_group(group_path, attrs={}, new_group_path=None, rest_client=No
     Args:
         group_path (str): group path (/parent/parent/name)
         attrs (dict): attributes to modify
-        new_group_path (str): new group path (/parent/parent/new-name)
+        new_group_name (str): new group name
     """
     groups = await list_groups(rest_client=rest_client)
     if group_path in groups:
@@ -129,9 +129,9 @@ async def modify_group(group_path, attrs={}, new_group_path=None, rest_client=No
                 ret['attributes'][k] = attrs[k]
             else:
                 ret['attributes'][k] = [attrs[k]]
-        if new_group_path:
-            ret['name'] = new_group_path.rsplit('/')[-1]
-            ret['path'] = new_group_path
+        if new_group_name:
+            ret['name'] = new_group_name
+            ret['path'] = ret['path'].rsplit('/', 1)[0] + '/' + new_group_name
         await rest_client.request('PUT', url, ret)
         logger.info(f'group "{group_path}" modified')
     else:
@@ -324,7 +324,7 @@ def main():
     parser_remove_user_group.set_defaults(func=remove_user_group)
     parser_modify = subparsers.add_parser('modify', help='modify an existing group')
     parser_modify.add_argument('group_path', help='group path (/parentA/parentB/name)')
-    parser_modify.add_argument('--new-group-path', metavar='PATH', help='change group name (/parentA/parentB/new-name)')
+    parser_modify.add_argument('--new-group-name', metavar='NAME', help='change group name')
     parser_modify.add_argument('attrs', nargs=argparse.REMAINDER,
                                help='space-separated NAME=VALUE attribute pairs. '
                                     'To delete NAME, omit VALUE. '

--- a/krs/groups.py
+++ b/krs/groups.py
@@ -324,7 +324,7 @@ def main():
     parser_remove_user_group.set_defaults(func=remove_user_group)
     parser_modify = subparsers.add_parser('modify', help='modify an existing group')
     parser_modify.add_argument('group_path', help='group path (/parentA/parentB/name)')
-    parser_modify.add_argument('--new-group-path', metavar='PATH', help='change group path (/parentA/parentB/name)')
+    parser_modify.add_argument('--new-group-path', metavar='PATH', help='change group name (/parentA/parentB/new-name)')
     parser_modify.add_argument('attrs', nargs=argparse.REMAINDER,
                                help='space-separated NAME=VALUE attribute pairs. '
                                     'To delete NAME, omit VALUE. '

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -30,7 +30,7 @@ exceptiongroup==1.1.2
     # via anyio
 google-api-core==2.11.1
     # via google-api-python-client
-google-api-python-client==2.94.0
+google-api-python-client==2.95.0
     # via wipac-keycloak-rest-services (setup.py)
 google-auth==2.22.0
     # via

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=actions --output-file=requirements-actions.txt
 #
-aio-pika==9.1.4
+aio-pika==9.1.5
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
@@ -14,7 +14,7 @@ cachetools==5.3.1
     # via
     #   google-auth
     #   wipac-rest-tools
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   httpcore
     #   requests

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=tests --output-file=requirements-tests.txt
 #
-aio-pika==9.1.4
+aio-pika==9.1.5
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
@@ -12,7 +12,7 @@ anyio==3.7.1
     # via httpcore
 cachetools==5.3.1
     # via wipac-rest-tools
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   httpcore
     #   requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-aio-pika==9.1.4
+aio-pika==9.1.5
     # via wipac-keycloak-rest-services (setup.py)
 aiormq==6.7.6
     # via aio-pika
@@ -12,7 +12,7 @@ anyio==3.7.1
     # via httpcore
 cachetools==5.3.1
     # via wipac-rest-tools
-certifi==2023.5.7
+certifi==2023.7.22
     # via
     #   httpcore
     #   requests

--- a/tests/krs/test_groups.py
+++ b/tests/krs/test_groups.py
@@ -75,7 +75,7 @@ async def test_modify_group_rename(keycloak_bootstrap):
     ret = await groups.group_info('/parent/group', rest_client=keycloak_bootstrap)
     assert ret['attributes'] == {'foo': 'bar'}
 
-    await groups.modify_group('/parent/group', new_group_path='/parent/group-new', rest_client=keycloak_bootstrap)
+    await groups.modify_group('/parent/group', new_group_name='group-new', rest_client=keycloak_bootstrap)
     ret = await groups.group_info('/parent/group-new', rest_client=keycloak_bootstrap)
     assert ret['attributes'] == {'foo': 'bar'}
 

--- a/tests/krs/test_groups.py
+++ b/tests/krs/test_groups.py
@@ -69,6 +69,17 @@ async def test_modify_group_del_attr(keycloak_bootstrap):
     assert ret['attributes'] == {'baz': 'foo'}
 
 @pytest.mark.asyncio
+async def test_modify_group_rename(keycloak_bootstrap):
+    await groups.create_group('/parent', rest_client=keycloak_bootstrap)
+    await groups.create_group('/parent/group', attrs={'foo':'bar'}, rest_client=keycloak_bootstrap)
+    ret = await groups.group_info('/parent/group', rest_client=keycloak_bootstrap)
+    assert ret['attributes'] == {'foo': 'bar'}
+
+    await groups.modify_group('/parent/group', new_group_path='/parent/group-new', rest_client=keycloak_bootstrap)
+    ret = await groups.group_info('/parent/group-new', rest_client=keycloak_bootstrap)
+    assert ret['attributes'] == {'foo': 'bar'}
+
+@pytest.mark.asyncio
 async def test_group_info_by_id(keycloak_bootstrap):
     with pytest.raises(Exception):
         await groups.group_info('/testgroup', rest_client=keycloak_bootstrap)


### PR DESCRIPTION
Unless I am doing something wrong, `krs.group --new-group-path` can only rename groups, not change their paths arbitrarily. This commit clarifies wording of --help and adds a test.