### PR TITLE
make get_group_membership raise GroupDoesNotExist instead of KeyError

### DIFF
--- a/krs/groups.py
+++ b/krs/groups.py
@@ -185,7 +185,7 @@ async def get_group_membership(group_path, rest_client=None):
     """
     groups = await list_groups(rest_client=rest_client)
     if group_path not in groups:
-        raise KeyError(f'group "{group_path}" does not exist')
+        raise GroupDoesNotExist
     group_id = groups[group_path]['id']
 
     return await get_group_membership_by_id(group_id, rest_client=rest_client)

--- a/krs/groups.py
+++ b/krs/groups.py
@@ -185,7 +185,7 @@ async def get_group_membership(group_path, rest_client=None):
     """
     groups = await list_groups(rest_client=rest_client)
     if group_path not in groups:
-        raise GroupDoesNotExist
+        raise GroupDoesNotExist(f'group "{group_path}" does not exist')
     group_id = groups[group_path]['id']
 
     return await get_group_membership_by_id(group_id, rest_client=rest_client)

--- a/requirements-actions.txt
+++ b/requirements-actions.txt
@@ -4,30 +4,24 @@
 #
 #    pip-compile --extra=actions --output-file=requirements-actions.txt
 #
-aio-pika==9.1.5
+aio-pika==9.2.0
     # via wipac-keycloak-rest-services (setup.py)
-aiormq==6.7.6
+aiormq==6.7.7
     # via aio-pika
-anyio==3.7.1
-    # via httpcore
 cachetools==5.3.1
     # via
     #   google-auth
     #   wipac-rest-tools
 certifi==2023.7.22
-    # via
-    #   httpcore
-    #   requests
+    # via requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
 cryptography==41.0.2
     # via pyjwt
-dnspython==2.4.0
+dnspython==2.4.1
     # via pymongo
-exceptiongroup==1.1.2
-    # via anyio
 google-api-core==2.11.1
     # via google-api-python-client
 google-api-python-client==2.95.0
@@ -42,19 +36,14 @@ google-auth-httplib2==0.1.0
     # via google-api-python-client
 google-auth-oauthlib==1.0.0
     # via wipac-keycloak-rest-services (setup.py)
-googleapis-common-protos==1.59.1
+googleapis-common-protos==1.60.0
     # via google-api-core
-h11==0.14.0
-    # via httpcore
-httpcore==0.17.3
-    # via dnspython
 httplib2==0.22.0
     # via
     #   google-api-python-client
     #   google-auth-httplib2
 idna==3.4
     # via
-    #   anyio
     #   requests
     #   yarl
 ldap3==2.9.1
@@ -84,7 +73,7 @@ pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
 pymongo==4.4.1
     # via motor
-pyparsing==3.1.0
+pyparsing==3.1.1
     # via httplib2
 pypng==0.20220715.0
     # via qrcode
@@ -108,11 +97,6 @@ six==1.16.0
     # via
     #   google-auth
     #   google-auth-httplib2
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   dnspython
-    #   httpcore
 tornado==6.3.2
     # via wipac-rest-tools
 typing-extensions==4.7.1

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -4,18 +4,14 @@
 #
 #    pip-compile --extra=tests --output-file=requirements-tests.txt
 #
-aio-pika==9.1.5
+aio-pika==9.2.0
     # via wipac-keycloak-rest-services (setup.py)
-aiormq==6.7.6
+aiormq==6.7.7
     # via aio-pika
-anyio==3.7.1
-    # via httpcore
 cachetools==5.3.1
     # via wipac-rest-tools
 certifi==2023.7.22
-    # via
-    #   httpcore
-    #   requests
+    # via requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
@@ -26,21 +22,14 @@ coverage[toml]==7.2.7
     #   wipac-keycloak-rest-services (setup.py)
 cryptography==41.0.2
     # via pyjwt
-dnspython==2.4.0
+dnspython==2.4.1
     # via pymongo
 exceptiongroup==1.1.2
-    # via
-    #   anyio
-    #   pytest
-flake8==6.0.0
+    # via pytest
+flake8==6.1.0
     # via wipac-keycloak-rest-services (setup.py)
-h11==0.14.0
-    # via httpcore
-httpcore==0.17.3
-    # via dnspython
 idna==3.4
     # via
-    #   anyio
     #   requests
     #   yarl
 iniconfig==2.0.0
@@ -61,11 +50,11 @@ pluggy==1.2.0
     # via pytest
 pyasn1==0.5.0
     # via ldap3
-pycodestyle==2.10.0
+pycodestyle==2.11.0
     # via flake8
 pycparser==2.21
     # via cffi
-pyflakes==3.0.1
+pyflakes==3.1.0
     # via flake8
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
@@ -95,11 +84,6 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   dnspython
-    #   httpcore
 tomli==2.0.1
     # via
     #   coverage

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,35 +4,24 @@
 #
 #    pip-compile --output-file=requirements.txt
 #
-aio-pika==9.1.5
+aio-pika==9.2.0
     # via wipac-keycloak-rest-services (setup.py)
-aiormq==6.7.6
+aiormq==6.7.7
     # via aio-pika
-anyio==3.7.1
-    # via httpcore
 cachetools==5.3.1
     # via wipac-rest-tools
 certifi==2023.7.22
-    # via
-    #   httpcore
-    #   requests
+    # via requests
 cffi==1.15.1
     # via cryptography
 charset-normalizer==3.2.0
     # via requests
 cryptography==41.0.2
     # via pyjwt
-dnspython==2.4.0
+dnspython==2.4.1
     # via pymongo
-exceptiongroup==1.1.2
-    # via anyio
-h11==0.14.0
-    # via httpcore
-httpcore==0.17.3
-    # via dnspython
 idna==3.4
     # via
-    #   anyio
     #   requests
     #   yarl
 ldap3==2.9.1
@@ -63,11 +52,6 @@ requests==2.31.0
     #   wipac-rest-tools
 requests-futures==1.0.1
     # via wipac-rest-tools
-sniffio==1.3.0
-    # via
-    #   anyio
-    #   dnspython
-    #   httpcore
 tornado==6.3.2
     # via wipac-rest-tools
 typing-extensions==4.7.1

--- a/tests/actions/test_create_posix_account.py
+++ b/tests/actions/test_create_posix_account.py
@@ -56,7 +56,7 @@ async def test_invalid_group(keycloak_bootstrap, ldap_bootstrap):
 
     await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', rest_client=keycloak_bootstrap)
 
-    with pytest.raises(KeyError):
+    with pytest.raises(groups.GroupDoesNotExist):
         await create_posix_account.process('/foofoo', keycloak_client=keycloak_bootstrap, ldap_client=ldap_bootstrap)
 
 @pytest.mark.asyncio

--- a/tests/krs/test_groups.py
+++ b/tests/krs/test_groups.py
@@ -127,7 +127,7 @@ async def test_get_user_groups(keycloak_bootstrap):
 
 @pytest.mark.asyncio
 async def test_add_user_group(keycloak_bootstrap):
-    with pytest.raises(Exception):
+    with pytest.raises(groups.GroupDoesNotExist):
         await groups.add_user_group('/testgroup', 'testuser', rest_client=keycloak_bootstrap)
 
     await users.create_user('testuser', first_name='first', last_name='last', email='email@test', rest_client=keycloak_bootstrap)
@@ -139,7 +139,7 @@ async def test_add_user_group(keycloak_bootstrap):
 
 @pytest.mark.asyncio
 async def test_remove_user_group(keycloak_bootstrap):
-    with pytest.raises(Exception):
+    with pytest.raises(groups.GroupDoesNotExist):
         await groups.remove_user_group('/testgroup', 'testuser', rest_client=keycloak_bootstrap)
 
     await users.create_user('testuser', first_name='first', last_name='last', email='email@test', rest_client=keycloak_bootstrap)
@@ -159,7 +159,7 @@ async def test_remove_user_group(keycloak_bootstrap):
 
 @pytest.mark.asyncio
 async def test_get_group_membership(keycloak_bootstrap):
-    with pytest.raises(Exception):
+    with pytest.raises(groups.GroupDoesNotExist):
         await groups.add_user_group('/testgroup', 'testuser', rest_client=keycloak_bootstrap)
 
     await users.create_user('testuser', first_name='first', last_name='last', email='email@test', rest_client=keycloak_bootstrap)


### PR DESCRIPTION
change groups.get_group_membership() to return GroupDoesNotExist instead of KeyError to be consistent.

I also missed a bunch of test cases earlier