### PR TITLE
user creation: handle duplicate canonical email addresses

### DIFF
--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -5,11 +5,11 @@ cachetools==5.3.2
 certifi==2024.2.2
 cffi==1.16.0
 charset-normalizer==3.3.2
-cryptography==42.0.2
-dnspython==2.5.0
+cryptography==42.0.4
+dnspython==2.6.1
 google-api-core==2.17.1
-google-api-python-client==2.118.0
-google-auth==2.27.0
+google-api-python-client==2.119.0
+google-auth==2.28.1
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.0
 googleapis-common-protos==1.62.0
@@ -20,12 +20,12 @@ motor==3.3.2
 multidict==6.0.5
 oauthlib==3.2.2
 pamqp==3.3.0
-protobuf==4.25.2
+protobuf==4.25.3
 pyasn1==0.5.1
 pyasn1-modules==0.3.0
 pycparser==2.21
 PyJWT==2.8.0
-pymongo==4.6.1
+pymongo==4.6.2
 pyparsing==3.1.1
 pypng==0.20220715.0
 qrcode==7.4.2
@@ -37,7 +37,7 @@ tornado==6.4
 typing_extensions==4.9.0
 Unidecode==1.3.8
 uritemplate==4.1.1
-urllib3==2.2.0
+urllib3==2.2.1
 wipac-dev-tools==1.9.1
 -e /home/keycloak
 wipac-rest-tools==1.6.0

--- a/tests/krs/test_users.py
+++ b/tests/krs/test_users.py
@@ -34,6 +34,16 @@ async def test_create_user(keycloak_bootstrap):
     assert ret['attributes'] == {'canonical_email': 'first.mu.last@icecube.wisc.edu'}
 
 @pytest.mark.asyncio
+async def test_create_user_same_names(keycloak_bootstrap):
+    await users.create_user('same-name-1', first_name='Fĭrst', last_name='Mü Lăst', email='foo1@test', rest_client=keycloak_bootstrap)
+    await users.create_user('same-name-2', first_name='Fĭrst', last_name='Mü Lăst', email='foo2@test', rest_client=keycloak_bootstrap)
+    user1 = await users.user_info('same-name-1', rest_client=keycloak_bootstrap)
+    assert user1['attributes']['canonical_email'] == 'first.mu.last@icecube.wisc.edu'
+    user2 = await users.user_info('same-name-2', rest_client=keycloak_bootstrap)
+    assert user2['attributes']['canonical_email'] != 'first.mu.last@icecube.wisc.edu'
+    assert user2['attributes']['canonical_email'].startswith('first.mu.last.')
+
+@pytest.mark.asyncio
 async def test_modify_user(keycloak_bootstrap):
     await users.create_user('testuser', first_name='first', last_name='last', email='foo@test', rest_client=keycloak_bootstrap)
     await users.modify_user('testuser', attribs={'foo': 'bar'}, rest_client=keycloak_bootstrap)


### PR DESCRIPTION
Existence of duplicate canonical email will break setup of Google Workspace accounts, which in turn may break mailing list setup.

I think the only time this has happened involved two accounts being created for the same user (not sure why), which resulted in the second account being incorrectly configured in Google Workspace