### PR TITLE
krs/token.py: increase default timeout

### DIFF
--- a/dependencies-from-Dockerfile.log
+++ b/dependencies-from-Dockerfile.log
@@ -9,7 +9,7 @@
 aio-pika==9.4.2
 aiormq==6.8.0
 asyncache==0.3.1
-attrs==23.2.0
+attrs==24.2.0
 cachetools==5.4.0
 certifi==2024.7.4
 cffi==1.16.0
@@ -129,7 +129,7 @@ wipac-keycloak-rest-services
 │   └── yarl [required: Any, installed: 1.9.4]
 │       ├── idna [required: >=2.0, installed: 3.7]
 │       └── multidict [required: >=4.0, installed: 6.0.5]
-├── attrs [required: Any, installed: 23.2.0]
+├── attrs [required: Any, installed: 24.2.0]
 ├── ldap3 [required: Any, installed: 2.9.1]
 │   └── pyasn1 [required: >=0.4.6, installed: 0.6.0]
 ├── motor [required: Any, installed: 3.5.1]

--- a/krs/token.py
+++ b/krs/token.py
@@ -23,7 +23,7 @@ def get_token(url, client_id, client_secret, client_realm='master'):
     return req['access_token']
 
 
-def get_rest_client(retries=None, timeout=10):
+def get_rest_client(retries=None, timeout=15):
     config = from_environment({
         'KEYCLOAK_REALM': 'icecube',
         'KEYCLOAK_URL': 'https://keycloak.icecube.wisc.edu',


### PR DESCRIPTION
We've been getting a lot of timeouts with 10s. It's a problem with keycloak, so this is hopefully a temporary work-around.