### PR TITLE
Re-enable the Testing Image's TLS Cert

### DIFF
--- a/dependencies-docker-krs.log
+++ b/dependencies-docker-krs.log
@@ -6,23 +6,23 @@
 ########################################################################
 #  pip freeze
 ########################################################################
-aio-pika==9.5.4
+aio-pika==9.5.5
 aiormq==6.8.1
 asyncache==0.3.1
 attrs==25.1.0
-cachetools==5.5.1
+cachetools==5.5.2
 certifi==2025.1.31
 cffi==1.17.1
 charset-normalizer==3.4.1
-cryptography==44.0.1
+cryptography==44.0.2
 dnspython==2.7.0
 exceptiongroup==1.2.2
 google-api-core==2.24.1
-google-api-python-client==2.161.0
+google-api-python-client==2.162.0
 google-auth==2.38.0
 google-auth-httplib2==0.2.0
 google-auth-oauthlib==1.2.1
-googleapis-common-protos==1.67.0
+googleapis-common-protos==1.69.0
 httplib2==0.22.0
 idna==3.10
 jsonpath-ng==1.7.0
@@ -32,14 +32,14 @@ multidict==6.1.0
 oauthlib==3.2.2
 pamqp==3.3.0
 ply==3.11
-propcache==0.2.1
+propcache==0.3.0
 proto-plus==1.26.0
 protobuf==5.29.3
 pyasn1==0.6.1
 pyasn1_modules==0.4.1
 pycparser==2.22
 PyJWT==2.10.1
-pymongo==4.11.1
+pymongo==4.11.2
 pyparsing==3.2.1
 qrcode==8.0
 requests==2.32.3
@@ -51,27 +51,27 @@ typing_extensions==4.12.2
 Unidecode==1.3.8
 uritemplate==4.1.1
 urllib3==2.3.0
-wipac-dev-tools==1.15.3
+wipac-dev-tools==1.15.6
 -e /home/keycloak
-wipac-rest-tools==1.8.5
+wipac-rest-tools==1.8.6
 yarl==1.18.3
 ########################################################################
 #  pipdeptree
 ########################################################################
 asyncache==0.3.1
-└── cachetools [required: >=5.2.0,<6.0.0, installed: 5.5.1]
-cryptography==44.0.1
+└── cachetools [required: >=5.2.0,<6.0.0, installed: 5.5.2]
+cryptography==44.0.2
 └── cffi [required: >=1.12, installed: 1.17.1]
     └── pycparser [required: Any, installed: 2.22]
-google-api-python-client==2.161.0
+google-api-python-client==2.162.0
 ├── google-api-core [required: >=1.31.5,<3.0.0.dev0,!=2.3.0,!=2.2.*,!=2.1.*,!=2.0.*, installed: 2.24.1]
 │   ├── google-auth [required: >=2.14.1,<3.0.dev0, installed: 2.38.0]
-│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.1]
+│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.2]
 │   │   ├── pyasn1_modules [required: >=0.2.1, installed: 0.4.1]
 │   │   │   └── pyasn1 [required: >=0.4.6,<0.7.0, installed: 0.6.1]
 │   │   └── rsa [required: >=3.1.4,<5, installed: 4.9]
 │   │       └── pyasn1 [required: >=0.1.3, installed: 0.6.1]
-│   ├── googleapis-common-protos [required: >=1.56.2,<2.0.dev0, installed: 1.67.0]
+│   ├── googleapis-common-protos [required: >=1.56.2,<2.0.dev0, installed: 1.69.0]
 │   │   └── protobuf [required: >=3.20.2,<6.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1, installed: 5.29.3]
 │   ├── proto-plus [required: >=1.22.3,<2.0.0dev, installed: 1.26.0]
 │   │   └── protobuf [required: >=3.19.0,<6.0.0dev, installed: 5.29.3]
@@ -82,14 +82,14 @@ google-api-python-client==2.161.0
 │       ├── idna [required: >=2.5,<4, installed: 3.10]
 │       └── urllib3 [required: >=1.21.1,<3, installed: 2.3.0]
 ├── google-auth [required: >=1.32.0,<3.0.0.dev0,!=2.25.0,!=2.24.0, installed: 2.38.0]
-│   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.1]
+│   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.2]
 │   ├── pyasn1_modules [required: >=0.2.1, installed: 0.4.1]
 │   │   └── pyasn1 [required: >=0.4.6,<0.7.0, installed: 0.6.1]
 │   └── rsa [required: >=3.1.4,<5, installed: 4.9]
 │       └── pyasn1 [required: >=0.1.3, installed: 0.6.1]
 ├── google-auth-httplib2 [required: >=0.2.0,<1.0.0, installed: 0.2.0]
 │   ├── google-auth [required: Any, installed: 2.38.0]
-│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.1]
+│   │   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.2]
 │   │   ├── pyasn1_modules [required: >=0.2.1, installed: 0.4.1]
 │   │   │   └── pyasn1 [required: >=0.4.6,<0.7.0, installed: 0.6.1]
 │   │   └── rsa [required: >=3.1.4,<5, installed: 4.9]
@@ -101,7 +101,7 @@ google-api-python-client==2.161.0
 └── uritemplate [required: >=3.0.1,<5, installed: 4.1.1]
 google-auth-oauthlib==1.2.1
 ├── google-auth [required: >=2.15.0, installed: 2.38.0]
-│   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.1]
+│   ├── cachetools [required: >=2.0.0,<6.0, installed: 5.5.2]
 │   ├── pyasn1_modules [required: >=0.2.1, installed: 0.4.1]
 │   │   └── pyasn1 [required: >=0.4.6,<0.7.0, installed: 0.6.1]
 │   └── rsa [required: >=3.1.4,<5, installed: 4.9]
@@ -121,25 +121,25 @@ pipdeptree==2.25.0
 setuptools==65.5.1
 wheel==0.45.1
 wipac-keycloak-rest-services
-├── aio-pika [required: Any, installed: 9.5.4]
+├── aio-pika [required: Any, installed: 9.5.5]
 │   ├── aiormq [required: >=6.8,<6.9, installed: 6.8.1]
 │   │   ├── pamqp [required: ==3.3.0, installed: 3.3.0]
 │   │   └── yarl [required: Any, installed: 1.18.3]
 │   │       ├── idna [required: >=2.0, installed: 3.10]
 │   │       ├── multidict [required: >=4.0, installed: 6.1.0]
 │   │       │   └── typing_extensions [required: >=4.1.0, installed: 4.12.2]
-│   │       └── propcache [required: >=0.2.0, installed: 0.2.1]
+│   │       └── propcache [required: >=0.2.0, installed: 0.3.0]
 │   ├── exceptiongroup [required: >=1,<2, installed: 1.2.2]
 │   └── yarl [required: Any, installed: 1.18.3]
 │       ├── idna [required: >=2.0, installed: 3.10]
 │       ├── multidict [required: >=4.0, installed: 6.1.0]
 │       │   └── typing_extensions [required: >=4.1.0, installed: 4.12.2]
-│       └── propcache [required: >=0.2.0, installed: 0.2.1]
+│       └── propcache [required: >=0.2.0, installed: 0.3.0]
 ├── attrs [required: Any, installed: 25.1.0]
 ├── ldap3 [required: Any, installed: 2.9.1]
 │   └── pyasn1 [required: >=0.4.6, installed: 0.6.1]
 ├── motor [required: Any, installed: 3.7.0]
-│   └── pymongo [required: >=4.9,<5.0, installed: 4.11.1]
+│   └── pymongo [required: >=4.9,<5.0, installed: 4.11.2]
 │       └── dnspython [required: >=1.16.0,<3.0.0, installed: 2.7.0]
 ├── requests [required: Any, installed: 2.32.3]
 │   ├── certifi [required: >=2017.4.17, installed: 2025.1.31]
@@ -147,15 +147,15 @@ wipac-keycloak-rest-services
 │   ├── idna [required: >=2.5,<4, installed: 3.10]
 │   └── urllib3 [required: >=1.21.1,<3, installed: 2.3.0]
 ├── Unidecode [required: Any, installed: 1.3.8]
-├── wipac-dev-tools [required: Any, installed: 1.15.3]
+├── wipac-dev-tools [required: Any, installed: 1.15.6]
 │   ├── requests [required: Any, installed: 2.32.3]
 │   │   ├── certifi [required: >=2017.4.17, installed: 2025.1.31]
 │   │   ├── charset-normalizer [required: >=2,<4, installed: 3.4.1]
 │   │   ├── idna [required: >=2.5,<4, installed: 3.10]
 │   │   └── urllib3 [required: >=1.21.1,<3, installed: 2.3.0]
 │   └── typing_extensions [required: Any, installed: 4.12.2]
-└── wipac-rest-tools [required: Any, installed: 1.8.5]
-    ├── cachetools [required: Any, installed: 5.5.1]
+└── wipac-rest-tools [required: Any, installed: 1.8.6]
+    ├── cachetools [required: Any, installed: 5.5.2]
     ├── PyJWT [required: !=2.6.0, installed: 2.10.1]
     ├── qrcode [required: Any, installed: 8.0]
     ├── requests [required: Any, installed: 2.32.3]
@@ -171,7 +171,7 @@ wipac-keycloak-rest-services
     │       └── urllib3 [required: >=1.21.1,<3, installed: 2.3.0]
     ├── tornado [required: Any, installed: 6.4.2]
     ├── urllib3 [required: >=2.0.4, installed: 2.3.0]
-    └── wipac-dev-tools [required: Any, installed: 1.15.3]
+    └── wipac-dev-tools [required: Any, installed: 1.15.6]
         ├── requests [required: Any, installed: 2.32.3]
         │   ├── certifi [required: >=2017.4.17, installed: 2025.1.31]
         │   ├── charset-normalizer [required: >=2,<4, installed: 3.4.1]

--- a/resources/keycloak-image/Dockerfile
+++ b/resources/keycloak-image/Dockerfile
@@ -16,7 +16,7 @@ ENV KK_TO_RMQ_VHOST=keycloak
 COPY keycloak_theme /opt/keycloak/themes/i3_theme
 
 # testing TLS cert
-#RUN keytool -genkeypair -storepass password -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore /opt/keycloak/conf/server.keystore
+RUN keytool -genkeypair -storepass password -storetype PKCS12 -keyalg RSA -keysize 2048 -dname "CN=server" -alias server -ext "SAN:c=DNS:localhost,IP:127.0.0.1" -keystore /opt/keycloak/conf/server.keystore
 
 RUN /opt/keycloak/bin/kc.sh build
 


### PR DESCRIPTION
The https://github.com/Observation-Management-Service/MQClient needs this for integration testing with a rabbitmq broker.